### PR TITLE
feat: 新增广播触发与发送动作

### DIFF
--- a/app/src/main/java/top/bogey/touch_tool/bean/action/ActionInfo.java
+++ b/app/src/main/java/top/bogey/touch_tool/bean/action/ActionInfo.java
@@ -123,6 +123,7 @@ import top.bogey.touch_tool.bean.action.start.ApplicationQuitStartAction;
 import top.bogey.touch_tool.bean.action.start.ApplicationStartAction;
 import top.bogey.touch_tool.bean.action.start.BatteryStartAction;
 import top.bogey.touch_tool.bean.action.start.BluetoothStartAction;
+import top.bogey.touch_tool.bean.action.start.BroadcastStartAction;
 import top.bogey.touch_tool.bean.action.start.ManualStartAction;
 import top.bogey.touch_tool.bean.action.start.NetworkStartAction;
 import top.bogey.touch_tool.bean.action.start.NotificationStartAction;
@@ -156,6 +157,7 @@ import top.bogey.touch_tool.bean.action.system.GetVolumeAction;
 import top.bogey.touch_tool.bean.action.system.PlayRingtoneAction;
 import top.bogey.touch_tool.bean.action.system.ReadFromClipboardAction;
 import top.bogey.touch_tool.bean.action.system.SendNotificationAction;
+import top.bogey.touch_tool.bean.action.system.SendBroadcastAction;
 import top.bogey.touch_tool.bean.action.system.SendToastAction;
 import top.bogey.touch_tool.bean.action.system.SetVolumeAction;
 import top.bogey.touch_tool.bean.action.system.ShareToAction;
@@ -193,6 +195,7 @@ public class ActionInfo {
     private final static ActionInfo SCREEN_START_INFO = new ActionInfo(ActionType.SCREEN_START, ScreenStartAction.class, R.drawable.icon_mobile, R.string.screen_start_action, R.string.screen_start_action_desc, 0, NormalActionCard.class);
     private final static ActionInfo BLUETOOTH_START_INFO = new ActionInfo(ActionType.BLUETOOTH_START, BluetoothStartAction.class, R.drawable.icon_bluetooth, R.string.bluetooth_start_action, R.string.bluetooth_start_action_desc, 0, NormalActionCard.class);
     private final static ActionInfo RECEIVED_SHARE_START_INFO = new ActionInfo(ActionType.RECEIVED_SHARE_START, ReceivedShareStartAction.class, R.drawable.icon_share, R.string.received_share_start_action, R.string.received_share_start_action_desc, 0, DynamicParamsActionCard.class);
+    private final static ActionInfo BROADCAST_START_INFO = new ActionInfo(ActionType.BROADCAST_START, BroadcastStartAction.class, R.drawable.icon_share, R.string.broadcast_start_action, R.string.broadcast_start_action_desc, 0, NormalActionCard.class);
     private final static ActionInfo OUT_CALL_START_INFO = new ActionInfo(ActionType.OUT_CALL_START, OutCallStartAction.class, R.drawable.icon_autoplay, R.string.out_call_start_action, R.string.out_call_start_action_desc, 0, DynamicParamsActionCard.class);
 
     // 自定义动作
@@ -246,6 +249,7 @@ public class ActionInfo {
     private final static ActionInfo TEXT_TO_SPEECH_INFO = new ActionInfo(ActionType.TEXT_TO_SPEECH, TextToSpeechAction.class, R.drawable.icon_text_to_speech, R.string.text_to_speak_action, R.string.text_to_speak_action_desc, 0, NormalActionCard.class);
     private final static ActionInfo VIBRATE_INFO = new ActionInfo(ActionType.VIBRATE, VibrateAction.class, R.drawable.icon_mobile_vibrate, R.string.vibrate_action, R.string.vibrate_action_desc, 0, NormalActionCard.class);
     private final static ActionInfo SEND_NOTIFICATION_INFO = new ActionInfo(ActionType.SEND_NOTIFICATION, SendNotificationAction.class, R.drawable.icon_notifications, R.string.send_notification_action, R.string.send_notification_action_desc, 0, NormalActionCard.class);
+    private final static ActionInfo SEND_BROADCAST_INFO = new ActionInfo(ActionType.SEND_BROADCAST, SendBroadcastAction.class, R.drawable.icon_share, R.string.send_broadcast_action, R.string.send_broadcast_action_desc, 0, NormalActionCard.class);
     private final static ActionInfo SEND_TOAST_INFO = new ActionInfo(ActionType.SEND_TOAST, SendToastAction.class, R.drawable.icon_toast, R.string.send_toast_action, R.string.send_toast_action_desc, 0, NormalActionCard.class);
 
     private final static ActionInfo WRITE_TO_CLIPBOARD_INFO = new ActionInfo(ActionType.WRITE_TO_CLIPBOARD, WriteToClipboardAction.class, R.drawable.icon_content_copy, R.string.write_to_clipboard_action, R.string.write_to_clipboard_action_desc, 0, NormalActionCard.class);
@@ -410,6 +414,7 @@ public class ActionInfo {
             case SCREEN_START -> SCREEN_START_INFO;
             case BLUETOOTH_START -> BLUETOOTH_START_INFO;
             case RECEIVED_SHARE_START -> RECEIVED_SHARE_START_INFO;
+            case BROADCAST_START -> BROADCAST_START_INFO;
             case OUT_CALL_START -> OUT_CALL_START_INFO;
 
             case CUSTOM_START -> CUSTOM_START_INFO;
@@ -458,6 +463,7 @@ public class ActionInfo {
             case TEXT_TO_SPEECH -> TEXT_TO_SPEECH_INFO;
             case VIBRATE -> VIBRATE_INFO;
             case SEND_NOTIFICATION -> SEND_NOTIFICATION_INFO;
+            case SEND_BROADCAST -> SEND_BROADCAST_INFO;
             case SEND_TOAST -> SEND_TOAST_INFO;
 
             case WRITE_TO_CLIPBOARD -> WRITE_TO_CLIPBOARD_INFO;

--- a/app/src/main/java/top/bogey/touch_tool/bean/action/ActionMap.java
+++ b/app/src/main/java/top/bogey/touch_tool/bean/action/ActionMap.java
@@ -23,6 +23,7 @@ public class ActionMap {
                     ActionType.SCREEN_START,
                     ActionType.BLUETOOTH_START,
                     ActionType.RECEIVED_SHARE_START,
+                    ActionType.BROADCAST_START,
                     ActionType.OUT_CALL_START,
                     ActionType.CUSTOM_START,
                     ActionType.CUSTOM_END
@@ -81,6 +82,7 @@ public class ActionMap {
                     ActionType.TEXT_TO_SPEECH,
                     ActionType.VIBRATE,
                     ActionType.SEND_NOTIFICATION,
+                    ActionType.SEND_BROADCAST,
                     ActionType.SEND_TOAST,
 
                     ActionType.WRITE_TO_CLIPBOARD,

--- a/app/src/main/java/top/bogey/touch_tool/bean/action/ActionType.java
+++ b/app/src/main/java/top/bogey/touch_tool/bean/action/ActionType.java
@@ -12,6 +12,7 @@ public enum ActionType {
     SCREEN_START,
     BLUETOOTH_START,
     RECEIVED_SHARE_START,
+    BROADCAST_START,
     OUT_CALL_START,
     INNER_START,
 
@@ -67,6 +68,7 @@ public enum ActionType {
     VIBRATE,
 
     SEND_NOTIFICATION,
+    SEND_BROADCAST,
     SEND_TOAST,
 
     WRITE_TO_CLIPBOARD,

--- a/app/src/main/java/top/bogey/touch_tool/bean/action/start/BroadcastStartAction.java
+++ b/app/src/main/java/top/bogey/touch_tool/bean/action/start/BroadcastStartAction.java
@@ -1,0 +1,68 @@
+package top.bogey.touch_tool.bean.action.start;
+
+import android.content.Intent;
+
+import com.google.gson.JsonObject;
+
+import java.util.Map;
+
+import top.bogey.touch_tool.R;
+import top.bogey.touch_tool.bean.action.ActionType;
+import top.bogey.touch_tool.bean.pin.Pin;
+import top.bogey.touch_tool.bean.pin.pin_objects.PinBase;
+import top.bogey.touch_tool.bean.pin.pin_objects.PinMap;
+import top.bogey.touch_tool.bean.pin.pin_objects.pin_string.PinString;
+import top.bogey.touch_tool.service.TaskInfoSummary;
+import top.bogey.touch_tool.service.TaskRunnable;
+
+public class BroadcastStartAction extends StartAction {
+    private final transient Pin actionPin = new Pin(new PinString(), R.string.broadcast_start_action_name);
+    private final transient Pin receivedActionPin = new Pin(new PinString(), R.string.broadcast_start_action_received_name, true);
+    private final transient Pin dataPin = new Pin(new PinString(), R.string.broadcast_start_action_data, true);
+    private final transient Pin extrasPin = new Pin(new PinMap(new PinString(), new PinString()), R.string.broadcast_start_action_extra, true);
+
+    public BroadcastStartAction() {
+        super(ActionType.BROADCAST_START);
+        addPins(actionPin, receivedActionPin, dataPin, extrasPin);
+    }
+
+    public BroadcastStartAction(JsonObject jsonObject) {
+        super(jsonObject);
+        reAddPins(actionPin, receivedActionPin, dataPin, extrasPin);
+    }
+
+    @Override
+    public void execute(TaskRunnable runnable, Pin pin) {
+        super.execute(runnable, pin);
+        TaskInfoSummary.BroadcastInfo broadcastInfo = TaskInfoSummary.getInstance().getBroadcastInfo();
+        if (broadcastInfo == null) return;
+        receivedActionPin.getValue(PinString.class).setValue(broadcastInfo.action());
+        String data = broadcastInfo.data();
+        dataPin.getValue(PinString.class).setValue(data == null ? "" : data);
+
+        Map<String, String> extras = broadcastInfo.extras();
+        extrasPin.setValue(PinBase.parseValue(extras));
+        executeNext(runnable, executePin);
+    }
+
+    @Override
+    public boolean ready() {
+        TaskInfoSummary.BroadcastInfo info = TaskInfoSummary.getInstance().getBroadcastInfo();
+        if (info == null) return false;
+        String action = actionPin.getValue(PinString.class).getValue();
+        if (action == null || action.isEmpty()) return false;
+        return action.equals(info.action());
+    }
+
+    public String getAction() {
+        return actionPin.getValue(PinString.class).getValue();
+    }
+
+    public static boolean isSystemAction(String action) {
+        if (action == null) return false;
+        return action.equals(Intent.ACTION_BATTERY_CHANGED)
+                || action.equals(Intent.ACTION_SCREEN_ON)
+                || action.equals(Intent.ACTION_SCREEN_OFF)
+                || action.equals(Intent.ACTION_USER_PRESENT);
+    }
+}

--- a/app/src/main/java/top/bogey/touch_tool/bean/action/system/SendBroadcastAction.java
+++ b/app/src/main/java/top/bogey/touch_tool/bean/action/system/SendBroadcastAction.java
@@ -1,0 +1,67 @@
+package top.bogey.touch_tool.bean.action.system;
+
+import android.content.Context;
+import android.content.Intent;
+
+import com.google.gson.JsonObject;
+
+import java.util.Map;
+
+import top.bogey.touch_tool.MainApplication;
+import top.bogey.touch_tool.R;
+import top.bogey.touch_tool.bean.action.ActionType;
+import top.bogey.touch_tool.bean.action.parent.ExecuteAction;
+import top.bogey.touch_tool.bean.pin.Pin;
+import top.bogey.touch_tool.bean.pin.pin_objects.PinMap;
+import top.bogey.touch_tool.bean.pin.pin_objects.pin_string.PinString;
+import top.bogey.touch_tool.service.TaskRunnable;
+
+public class SendBroadcastAction extends ExecuteAction {
+    private final transient Pin actionPin = new Pin(new PinString(), R.string.send_broadcast_action_name);
+    private final transient Pin packagePin = new Pin(new PinString(), R.string.send_broadcast_action_package);
+    private final transient Pin dataPin = new Pin(new PinString(), R.string.send_broadcast_action_data);
+    private final transient Pin extrasPin = new Pin(new PinMap(new PinString(), new PinString()), R.string.send_broadcast_action_extra);
+
+    public SendBroadcastAction() {
+        super(ActionType.SEND_BROADCAST);
+        addPins(actionPin, packagePin, dataPin, extrasPin);
+    }
+
+    public SendBroadcastAction(JsonObject jsonObject) {
+        super(jsonObject);
+        reAddPins(actionPin, packagePin, dataPin, extrasPin);
+    }
+
+    @Override
+    public void execute(TaskRunnable runnable, Pin pin) {
+        PinString action = getPinValue(runnable, actionPin);
+        if (action == null || action.getValue() == null || action.getValue().isEmpty()) {
+            executeNext(runnable, outPin);
+            return;
+        }
+
+        Intent intent = new Intent(action.getValue());
+
+        PinString packageName = getPinValue(runnable, packagePin);
+        if (packageName != null && packageName.getValue() != null && !packageName.getValue().isEmpty()) {
+            intent.setPackage(packageName.getValue());
+        }
+
+        PinString data = getPinValue(runnable, dataPin);
+        if (data != null && data.getValue() != null && !data.getValue().isEmpty()) {
+            intent.setData(android.net.Uri.parse(data.getValue()));
+        }
+
+        PinMap map = getPinValue(runnable, extrasPin);
+        if (map != null) {
+            for (Map.Entry<String, String> entry : map.getValue(PinString.class, PinString.class).entrySet()) {
+                if (entry.getKey() == null) continue;
+                intent.putExtra(entry.getKey(), entry.getValue());
+            }
+        }
+
+        Context context = MainApplication.getInstance();
+        context.sendBroadcast(intent);
+        executeNext(runnable, outPin);
+    }
+}

--- a/app/src/main/java/top/bogey/touch_tool/service/MainAccessibilityService.java
+++ b/app/src/main/java/top/bogey/touch_tool/service/MainAccessibilityService.java
@@ -416,6 +416,7 @@ public class MainAccessibilityService extends AccessibilityService {
 
     public void replaceAlarm(Task task) {
         if (task == null) return;
+        refreshStartReceiver();
         Task originTask = TaskSaver.getInstance().getOriginTask(task.getId());
         List<Action> actions = task.getActions(TimeStartAction.class);
 
@@ -445,6 +446,11 @@ public class MainAccessibilityService extends AccessibilityService {
                 cancelAlarm(task, timeStartAction);
             }
         });
+    }
+
+    private void refreshStartReceiver() {
+        if (systemEventReceiver == null) return;
+        systemEventReceiver.refreshBroadcastStartReceiver();
     }
 
     // 定时 ----------------------------------------------------------------------------- end

--- a/app/src/main/java/top/bogey/touch_tool/service/TaskInfoSummary.java
+++ b/app/src/main/java/top/bogey/touch_tool/service/TaskInfoSummary.java
@@ -28,6 +28,7 @@ import top.bogey.touch_tool.bean.action.start.ApplicationQuitStartAction;
 import top.bogey.touch_tool.bean.action.start.ApplicationStartAction;
 import top.bogey.touch_tool.bean.action.start.BatteryStartAction;
 import top.bogey.touch_tool.bean.action.start.BluetoothStartAction;
+import top.bogey.touch_tool.bean.action.start.BroadcastStartAction;
 import top.bogey.touch_tool.bean.action.start.ManualStartAction;
 import top.bogey.touch_tool.bean.action.start.NetworkStartAction;
 import top.bogey.touch_tool.bean.action.start.NotificationStartAction;
@@ -77,6 +78,7 @@ public class TaskInfoSummary {
     private Notification notification;
     private BatteryInfo batteryInfo;
     private BluetoothInfo bluetoothInfo;
+    private BroadcastInfo broadcastInfo;
     private String lastClipboard;
     private List<NotworkState> networkState;
 
@@ -472,6 +474,15 @@ public class TaskInfoSummary {
         tryStartActions(BluetoothStartAction.class);
     }
 
+    public BroadcastInfo getBroadcastInfo() {
+        return broadcastInfo;
+    }
+
+    public void setBroadcastInfo(String action, String data, Map<String, String> extras) {
+        broadcastInfo = new BroadcastInfo(action, data, extras);
+        tryStartActions(BroadcastStartAction.class);
+    }
+
     public PhoneState getPhoneState() {
         return AppUtil.getPhoneState(MainApplication.getInstance());
     }
@@ -525,6 +536,9 @@ public class TaskInfoSummary {
     }
 
     public record BluetoothInfo(String bluetoothAddress, String bluetoothName, boolean active) {
+    }
+
+    public record BroadcastInfo(String action, String data, Map<String, String> extras) {
     }
 
     public record ManualExecuteInfo(Task task, ManualStartAction action) {

--- a/app/src/main/java/top/bogey/touch_tool/service/receiver/SystemEventReceiver.java
+++ b/app/src/main/java/top/bogey/touch_tool/service/receiver/SystemEventReceiver.java
@@ -16,14 +16,34 @@ import androidx.core.content.ContextCompat;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import top.bogey.touch_tool.bean.action.Action;
+import top.bogey.touch_tool.bean.action.start.BroadcastStartAction;
+import top.bogey.touch_tool.bean.save.task.TaskSaver;
+import top.bogey.touch_tool.bean.task.Task;
 import top.bogey.touch_tool.service.TaskInfoSummary;
 import top.bogey.touch_tool.ui.InstantActivity;
 
 public class SystemEventReceiver extends BroadcastReceiver {
     private final Context context;
     private ConnectivityManager.NetworkCallback networkCallback;
+
+    private final BroadcastReceiver broadcastStartReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            String action = intent.getAction();
+            if (action == null) return;
+            String data = null;
+            if (intent.getData() != null) {
+                data = intent.getData().toString();
+            }
+            TaskInfoSummary.getInstance().setBroadcastInfo(action, data, parseExtras(intent));
+        }
+    };
+    private boolean broadcastRegistered = false;
 
     public SystemEventReceiver(Context context) {
         this.context = context;
@@ -80,11 +100,50 @@ public class SystemEventReceiver extends BroadcastReceiver {
     public void register() {
         ContextCompat.registerReceiver(context, this, getFilter(), ContextCompat.RECEIVER_EXPORTED);
         registerNetworkReceiver();
+        refreshBroadcastStartReceiver();
     }
 
     public void unregister() {
         context.unregisterReceiver(this);
         unregisterNetworkReceiver();
+        unregisterBroadcastStartReceiver();
+    }
+
+    @SuppressLint("UnspecifiedRegisterReceiverFlag")
+    public void refreshBroadcastStartReceiver() {
+        unregisterBroadcastStartReceiver();
+
+        IntentFilter filter = new IntentFilter();
+        for (Task task : TaskSaver.getInstance().getTasks(BroadcastStartAction.class)) {
+            for (Action action : task.getActions(BroadcastStartAction.class)) {
+                BroadcastStartAction startAction = (BroadcastStartAction) action;
+                if (!startAction.isEnable()) continue;
+                String actionName = startAction.getAction();
+                if (actionName == null || actionName.isEmpty()) continue;
+                if (BroadcastStartAction.isSystemAction(actionName)) continue;
+                filter.addAction(actionName);
+            }
+        }
+
+        if (filter.countActions() == 0) return;
+        ContextCompat.registerReceiver(context, broadcastStartReceiver, filter, ContextCompat.RECEIVER_EXPORTED);
+        broadcastRegistered = true;
+    }
+
+    private void unregisterBroadcastStartReceiver() {
+        if (!broadcastRegistered) return;
+        context.unregisterReceiver(broadcastStartReceiver);
+        broadcastRegistered = false;
+    }
+
+    private Map<String, String> parseExtras(Intent intent) {
+        Map<String, String> map = new HashMap<>();
+        if (intent.getExtras() == null) return map;
+        for (String key : intent.getExtras().keySet()) {
+            Object value = intent.getExtras().get(key);
+            map.put(key, value == null ? "" : String.valueOf(value));
+        }
+        return map;
     }
 
     private void registerNetworkReceiver() {

--- a/app/src/main/res/values/task_strings.xml
+++ b/app/src/main/res/values/task_strings.xml
@@ -63,6 +63,13 @@
     <string name="received_share_start_action">收到分享时执行</string>
     <string name="received_share_start_action_desc">接受分享行为，分享的内容将自动转换为对应参数</string>
 
+    <string name="broadcast_start_action">收到广播时执行</string>
+    <string name="broadcast_start_action_desc">收到指定广播时自动执行</string>
+    <string name="broadcast_start_action_name">广播名</string>
+    <string name="broadcast_start_action_received_name">收到广播</string>
+    <string name="broadcast_start_action_data">Data</string>
+    <string name="broadcast_start_action_extra">Extra</string>
+
     <string name="out_call_start_action">外部调用</string>
     <string name="out_call_start_action_desc">外部调用任务，能自动将传入的参数转换到任务内同名变量中去</string>
     <string name="out_call_start_action_url">链接</string>
@@ -259,6 +266,13 @@
     <string name="send_notification_action_icon">图标</string>
     <string name="send_notification_action_auto_cancel">自动取消</string>
     <string name="send_notification_action_execute">点按执行</string>
+
+    <string name="send_broadcast_action">发送广播</string>
+    <string name="send_broadcast_action_desc">发送自定义广播</string>
+    <string name="send_broadcast_action_name">广播名</string>
+    <string name="send_broadcast_action_package">目标应用包名</string>
+    <string name="send_broadcast_action_data">Data</string>
+    <string name="send_broadcast_action_extra">Extra</string>
 
     <string name="send_toast_action">弹出提示</string>
     <string name="send_toast_action_desc">弹出自定义提示文本</string>


### PR DESCRIPTION
### Motivation

- 支持通过广播触发任务和从任务中发送自定义广播，便于与外部组件或第三方应用进行事件联动。 
- 需要在运行时动态注册/反注册广播，避免与已有系统广播冲突并确保任务变更后监听及时更新。

### Description

- 新增开始动作 `BroadcastStartAction`，可配置监听的广播 Action 并在触发时输出收到的 Action、Data 与 Extras（字典）。
- 新增系统动作 `SendBroadcastAction`，支持设置广播名、目标包名、Data 与 Extras 并调用 `sendBroadcast` 发送。
- 将动作接入体系：在 `ActionType`、`ActionMap`、`ActionInfo` 中注册两个新动作并在 `task_strings.xml` 中增加相应文案。 
- 在 `TaskInfoSummary` 中增加 `BroadcastInfo` 缓存与 `setBroadcastInfo`/`getBroadcastInfo` 接口用于触发开始动作。 
- 在 `SystemEventReceiver` 中加入动态广播注册/反注册逻辑（根据启用的 `BroadcastStartAction` 构建 `IntentFilter` 并解析 extras），以及接收到广播时将事件写入 `TaskInfoSummary`。 
- 在 `MainAccessibilityService.replaceAlarm` 中调用 `refreshStartReceiver()` 以保证任务保存/删除后广播监听及时刷新。

### Testing

- 运行 `./gradlew :app:compileDebugJavaWithJavac` 失败，原因是 Gradle Wrapper 在当前环境下无法从网络下载分发包（代理返回 403）。
- 运行 `gradle :app:compileDebugJavaWithJavac` 失败，构建在本环境因 Java/Gradle 组合问题提前退出（构建失败）。
- 运行 `gradle -v` 成功并显示可用 Gradle 版本信息；其余变更已通过 static edits 并已提交到本地仓库。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bfedbdfe8832b82a05093664f7caf)